### PR TITLE
Patch 1.3.1 for missing typing and ActionExtension issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG for 1.x
 ===================
 
+## v1.3.1 - (2022-08-10)
+
+### Fixed
+
+- [[#37](https://github.com/smartbooster/sonata-bundle/issues/37)] Fix UserTrait name setter typping for Phpstan
+- [[#31](https://github.com/smartbooster/sonata-bundle/issues/31)] Fix old namespace SmartAuthentication with SmartSonata on templates/email/{locale}
+- Fixed missing typing on UserTrait that prevent creating user on Admin 
+- Fixed missnaming of NAME_ACTIONS in ActionExtension to keep one column for it
+
 ## v1.3.0 - (2022-08-08)
 
 ### Added

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2,7 +2,7 @@
 
 namespace Smart\SonataBundle\Admin;
 
-use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -24,6 +24,11 @@ abstract class AbstractAdmin extends \Sonata\AdminBundle\Admin\AbstractAdmin
         parent::__construct($code, $class, $baseControllerName);
     }
 
+    protected function configureRoutes(RouteCollectionInterface $collection): void
+    {
+        $collection->remove('export');
+    }
+
     /**
      * Remove default batch as customer never really want default behavior
      */
@@ -32,15 +37,6 @@ abstract class AbstractAdmin extends \Sonata\AdminBundle\Admin\AbstractAdmin
         unset($actions['delete']);
 
         return $actions;
-    }
-
-    /**
-     * Remove default export as customer never really want default behavior
-     * @return string[]
-     */
-    public function getExportFormats(): array
-    {
-        return [];
     }
 
     /**

--- a/src/Admin/Extension/ActionExtension.php
+++ b/src/Admin/Extension/ActionExtension.php
@@ -34,13 +34,13 @@ class ActionExtension extends AbstractAdminExtension
             return;
         }
 
-        if (!$list->has('_action')) {
+        if (!$list->has(ListMapper::NAME_ACTIONS)) {
             $this->createActionField($list);
 
             return;
         }
 
-        $field = $list->get('_action');
+        $field = $list->get(ListMapper::NAME_ACTIONS);
 
         if ('actions' === $field->getType()) {
             $this->alterActionField($field);
@@ -72,7 +72,7 @@ class ActionExtension extends AbstractAdminExtension
      */
     private function createActionField(ListMapper $list)
     {
-        $list->add('_action', 'actions', [
+        $list->add(ListMapper::NAME_ACTIONS, 'actions', [
             'actions' => [
                 $this->action => [
                     'template' => sprintf('@SmartSonata/action/%s.html.twig', $this->action)

--- a/src/Controller/AbstractSecurityController.php
+++ b/src/Controller/AbstractSecurityController.php
@@ -98,7 +98,6 @@ class AbstractSecurityController extends AbstractController
         }
 
         try {
-            $this->container->get('doctrine');
             $user = $this->getUserProvider()->loadUserByUsername($form->get('email')->getData());
 
             if ($user instanceof SmartUserInterface) {

--- a/src/Entity/User/UserTrait.php
+++ b/src/Entity/User/UserTrait.php
@@ -20,7 +20,7 @@ trait UserTrait
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    protected ?int $id;
+    protected ?int $id = null;
 
     /**
      * @var string
@@ -220,7 +220,7 @@ trait UserTrait
     }
 
     /**
-     * @param string $firstName
+     * @param string|null $firstName
      *
      * @return $this
      */
@@ -240,7 +240,7 @@ trait UserTrait
     }
 
     /**
-     * @param string $lastName
+     * @param string|null $lastName
      *
      * @return $this
      */

--- a/templates/email/en/admin/security/account_creation.html.twig
+++ b/templates/email/en/admin/security/account_creation.html.twig
@@ -1,1 +1,1 @@
-{% extends '@SmartAuthentication/email/admin/security/account_creation.html.twig' %}
+{% extends '@SmartSonata/email/admin/security/account_creation.html.twig' %}

--- a/templates/email/en/admin/security/forgot_password.html.twig
+++ b/templates/email/en/admin/security/forgot_password.html.twig
@@ -1,1 +1,1 @@
-{% extends '@SmartAuthentication/email/admin/security/forgot_password.html.twig' %}
+{% extends '@SmartSonata/email/admin/security/forgot_password.html.twig' %}

--- a/templates/email/fr/admin/security/account_creation.html.twig
+++ b/templates/email/fr/admin/security/account_creation.html.twig
@@ -1,1 +1,1 @@
-{% extends '@SmartAuthentication/email/admin/security/account_creation.html.twig' %}
+{% extends '@SmartSonata/email/admin/security/account_creation.html.twig' %}

--- a/templates/email/fr/admin/security/forgot_password.html.twig
+++ b/templates/email/fr/admin/security/forgot_password.html.twig
@@ -1,1 +1,1 @@
-{% extends '@SmartAuthentication/email/admin/security/forgot_password.html.twig' %}
+{% extends '@SmartSonata/email/admin/security/forgot_password.html.twig' %}

--- a/translations/admin.en.xlf
+++ b/translations/admin.en.xlf
@@ -3,8 +3,8 @@
     <file source-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <!-- Lists Action -->
-            <trans-unit id="list.label__action">
-                <source>list.label__action</source>
+            <trans-unit id="list.label__actions">
+                <source>list.label__actions</source>
                 <target>Actions</target>
             </trans-unit>
             <trans-unit id="list.action_delete">

--- a/translations/admin.fr.xlf
+++ b/translations/admin.fr.xlf
@@ -3,8 +3,8 @@
     <file source-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <!-- Lists Action -->
-            <trans-unit id="list.label__action">
-                <source>list.label__action</source>
+            <trans-unit id="list.label__actions">
+                <source>list.label__actions</source>
                 <target>Actions</target>
             </trans-unit>
             <trans-unit id="list.action_delete">


### PR DESCRIPTION
### Fixed

- [[#37](https://github.com/smartbooster/sonata-bundle/issues/37)] Fix UserTrait name setter typping for Phpstan
- [[#31](https://github.com/smartbooster/sonata-bundle/issues/31)] Fix old namespace SmartAuthentication with SmartSonata on templates/email/{locale}
- Fixed missing typing on UserTrait that prevent creating user on Admin 
- Fixed missnaming of NAME_ACTIONS in ActionExtension to keep one column for it