### PR TITLE
Update php 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     container: smartbooster/php-fpm:${{ matrix.php }}-builder
     strategy:
       matrix:
-        php: [ 7.4 ]
+        php: [ 8.2 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 CHANGELOG for 1.x
 ===================
+## v1.4.7 - (2023-07-28)
+
+### Update
+
+- Update composer php version to use ^8.0 and add possibility to use version ^7.0 of `dama/doctrine-test-bundle`
+- Update github action to run tests on php 8.2
+
 ## v1.4.6 - (2023-07-13)
 
 ### Update

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": "^7.4",
+    "php": "^7.4 || ^8.0",
     "sonata-project/doctrine-orm-admin-bundle": "^4.2",
     "sonata-project/intl-bundle": "^2.12 || ^3.0",
     "doctrine/doctrine-fixtures-bundle": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "phpmetrics/phpmetrics": "^2.8",
     "phpunit/phpunit": "^9.5 || ^10.2",
     "phpstan/phpstan-symfony": "^1.2",
-    "dama/doctrine-test-bundle": "^6.6",
+    "dama/doctrine-test-bundle": "^6.6 || ^7.0",
     "liip/test-fixtures-bundle": "^2.4",
     "phpstan/phpstan-doctrine": "^1.3",
     "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0"


### PR DESCRIPTION
- Update composer php version to use ^8.0 and add possibility to use version ^7.0 of `dama/doctrine-test-bundle`
- Update github action to run tests on php 8.2