### PR TITLE
Add annotations for orm mapping in addition to attributes to be compatible with both implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 CHANGELOG
 ===================
+## v2.1.1 - (2024-03-28)
+
+### Added
+- Add annotations for orm mapping in addition to attributes to be compatible with both implementation
+
+### Fixed
+- `BatchLog::date` type to `DATETIME_MUTABLE` (type error introduce in update v2.0.0)
+- `UserTrait::lastLogin` type to `DATETIME_MUTABLE` (type error introduce in update v2.0.0)
+
 ## v2.1.0 - (2024-03-17)
 
 ### Uprade guide

--- a/src/Entity/Log/BatchLog.php
+++ b/src/Entity/Log/BatchLog.php
@@ -8,34 +8,63 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @author Louis Fortunier <louis.fortunier@smartbooster.io>
+ *
+ * @ORM\Table(name="batch_log")
+ * @ORM\Entity(repositoryClass="Smart\SonataBundle\Repository\Log\BatchLogRepository")
  */
 #[ORM\Table(name: 'batch_log')]
 #[ORM\Entity(repositoryClass: BatchLogRepository::class)]
 class BatchLog
 {
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    /**
+     * @ORM\Column(type=Types::DATETIME_MUTABLE)
+     */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     private ?\DateTime $date = null;
 
+    /**
+     * @ORM\Column(length=255)
+     */
     #[ORM\Column(length: 255)]
     private ?string $context = null;
 
+    /**
+     * @ORM\Column(length=255)
+     */
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $summary = null;
 
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private ?string $comment = null;
 
+    /**
+     * @ORM\Column(nullable=true)
+     */
     #[ORM\Column(nullable: true)]
     private ?array $data = null;
 
+    /**
+     * @ORM\Column(nullable=true)
+     */
     #[ORM\Column(nullable: true)]
     private ?bool $success = null;
 

--- a/src/Entity/Log/HistorizableTrait.php
+++ b/src/Entity/Log/HistorizableTrait.php
@@ -13,6 +13,9 @@ trait HistorizableTrait
 {
     private ?PropertyAccessorInterface $propertyAccess = null;
 
+    /**
+     * @ORM\Column(nullable=true)
+     */
     #[ORM\Column(nullable: true)]
     protected ?array $history = null;
 

--- a/src/Entity/Parameter.php
+++ b/src/Entity/Parameter.php
@@ -13,6 +13,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @author Mathieu Ducrot <mathieu.ducrot@smartbooster.io>
+ *
+ * @ORM\Table(name="smart_parameter")
+ * @ORM\Entity(repositoryClass="Smart\SonataBundle\Repository\ParameterRepository")
  */
 #[ORM\Table(name: "smart_parameter")]
 #[ORM\Entity(repositoryClass: "Smart\SonataBundle\Repository\ParameterRepository")]
@@ -20,25 +23,44 @@ class Parameter implements ParameterInterface
 {
     use HistorizableTrait;
 
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
+    /**
+     * @ORM\Column(name="code", unique=true, nullable=false)
+     */
     #[ORM\Column(name: "code", unique: true, nullable: false)]
     private string $code;
 
+    /**
+     * @ORM\Column(name="value", type="text", nullable=false)
+     */
     #[ORM\Column(name: "value", type: Types::TEXT, nullable: false)]
     private string|bool|null $value = null;
 
+    /**
+     * @ORM\Column(name="help", type="text", nullable=true)
+     */
     #[ORM\Column(name: "help", type: Types::TEXT, nullable: true)]
     private ?string $help = null;
 
+    /**
+     * @ORM\Column(length=15, nullable=false, options={"default"="text"})
+     */
     #[ORM\Column(length: 15, nullable: false, options: ['default' => 'text'])]
     private string $type = ParameterTypeEnum::TEXT;
 
     /**
      * MDT We don't need to set the start/end delimiter when setting the regex, it is automatically added when the validate callback is triggered
+     * @ORM\Column(length=100, nullable=true)
+     * @Assert\Length(max=100)
      */
     #[ORM\Column(length: 100, nullable: true)]
     #[Assert\Length(max: 100)]
@@ -46,6 +68,7 @@ class Parameter implements ParameterInterface
 
     /**
      * @param mixed $payload
+     * @Assert\Callback
      */
     #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, $payload): void

--- a/src/Entity/User/PasswordSafeableTrait.php
+++ b/src/Entity/User/PasswordSafeableTrait.php
@@ -6,6 +6,9 @@ use Smart\CoreBundle\Validator\Constraints as SmartAssert;
 
 trait PasswordSafeableTrait
 {
+    /**
+     * @SmartAssert\IsPasswordSafe
+     */
     #[SmartAssert\IsPasswordSafe]
     private ?string $plainPassword = null;
 }

--- a/src/Entity/User/UserTrait.php
+++ b/src/Entity/User/UserTrait.php
@@ -15,28 +15,50 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 trait UserTrait
 {
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     protected ?int $id = null;
 
+    /**
+     * @ORM\Column(length=255, unique=true, nullable=false)
+     * @Assert\NotBlank
+     * @Assert\Email
+     */
     #[ORM\Column(length: 255, unique: true, nullable: false)]
     #[Assert\NotBlank]
     #[Assert\Email]
     private ?string $email = null;
 
+    /**
+     * @ORM\Column(name="password", length=100, nullable=false)
+     */
     #[ORM\Column(name: "password", length: 100, nullable: false)]
     private ?string $password = null;
 
     private ?string $plainPassword = null;
 
+    /**
+     * @ORM\Column(length=255, nullable=true)
+     */
     #[ORM\Column(length: 255, nullable: true)]
     protected ?string $firstName = null;
 
+    /**
+     * @ORM\Column(length=255, nullable=true)
+     */
     #[ORM\Column(length: 255, nullable: true)]
     protected ?string $lastName = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
+    /**
+     * @ORM\Column(type=Types::DATETIME_MUTABLE, nullable=true)
+     */
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
     protected ?DateTime $lastLogin = null;
 
     public function __toString()


### PR DESCRIPTION
### Added
- Add annotations for orm mapping in addition to attributes to be compatible with both implementation

### Fixed
- `BatchLog::date` type to `DATETIME_MUTABLE` (type error introduce in update v2.0.0)
- `UserTrait::lastLogin` type to `DATETIME_MUTABLE` (type error introduce in update v2.0.0)