### PR TITLE
add `default_admin_services.security_handler: Smart\SonataBundle\Security\Handler\SmartSecurityHandler` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG
 ===================
+## v2.8.2 - (2024-10-09)
+### Fixed
+- `bundle_prepend_config.yml` add `default_admin_services.security_handler: Smart\SonataBundle\Security\Handler\SmartSecurityHandler` option because `security.handler` don't work
+
 ## v2.8.1 - (2024-09-24)
 ### Added
 - `list_api_call_route_url.html.twig` template to reduce the size of the url on `AbstractApiCallAdmin`

--- a/config/bundle_prepend_config.yml
+++ b/config/bundle_prepend_config.yml
@@ -8,8 +8,10 @@ sonata_admin:
         default_translation_domain: 'admin'
     default_admin_services:
         label_translator_strategy: 'sonata.admin.label.strategy.underscore'
+        # added because security.handler don't work. if there is "No entity manager defined" error, check if your smartIsGranted function work properly
+        security_handler: Smart\SonataBundle\Security\Handler\SmartSecurityHandler
     security:
-        handler:   Smart\SonataBundle\Security\Handler\SmartSecurityHandler
+        handler: Smart\SonataBundle\Security\Handler\SmartSecurityHandler
     extensions:
         admin.extension.action_restart_api_call:
             implements:


### PR DESCRIPTION
`bundle_prepend_config.yml` add `default_admin_services.security_handler: Smart\SonataBundle\Security\Handler\SmartSecurityHandler` option because `security.handler` don't work